### PR TITLE
Connection close header

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -251,7 +251,7 @@ checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 [[package]]
 name = "httplus"
 version = "0.1.0"
-source = "git+https://github.com/4ydx/httplus.git#71ca545152b02e927b5fe96b7eb49913a3b4efa7"
+source = "git+https://github.com/4ydx/httplus.git#fc5720a6c5ffb408343798e106c9c952a12b5f4a"
 dependencies = [
  "base64",
  "encoding",
@@ -275,9 +275,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.6.0"
+version = "2.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76fc44e2588d5b436dbc3c6cf62aef290f90dab6235744a93dfe1cc18f451e2c"
+checksum = "5486aed0026218e61b8a01d5fbd5a0a134649abb71a0e53b7bc088529dced86e"
 
 [[package]]
 name = "miniz_oxide"

--- a/run.sh
+++ b/run.sh
@@ -1,2 +1,2 @@
 cargo build
- ./target/debug/rust-server --socket-address 0.0.0.0:9999
+ ./target/debug/rust-echo-server --socket-address 0.0.0.0:9999

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,7 +58,7 @@ async fn serve(socket_address: &str) -> io::Result<()> {
                 if n == 0 {
                     break 'outer;
                 }
-                request.update(&mut rd_external_client_buffer[0..n].to_vec());
+                request.update_raw(&mut rd_external_client_buffer[0..n].to_vec());
 
                 if request.body_complete() {
                     break 'outer;
@@ -74,7 +74,7 @@ async fn serve(socket_address: &str) -> io::Result<()> {
             };
 
             let content = format!(
-                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
+                "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: {}\r\n\r\n{}",
                 entire_request.len(),
                 entire_request,
             );
@@ -132,7 +132,7 @@ mod tests {
         let rl = proxy.read(read_buffer).await.unwrap();
         let message_out = str::from_utf8(&read_buffer[0..rl]).unwrap();
 
-        let expect = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 32\r\n\r\nGET / HTTP/1.1\r\nOther: other\r\n\r\n";
+        let expect = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: 32\r\n\r\nGET / HTTP/1.1\r\nOther: other\r\n\r\n";
         assert_eq!(expect, message_out);
 
         // basic POST request
@@ -148,7 +148,7 @@ mod tests {
         let rl = proxy.read(read_buffer).await.unwrap();
         let message_out = str::from_utf8(&read_buffer[0..rl]).unwrap();
 
-        let expect = "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 42\r\n\r\nPOST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nBODY";
+        let expect = "HTTP/1.1 200 OK\r\nConnection: close\r\nContent-Type: text/plain\r\nContent-Length: 42\r\n\r\nPOST / HTTP/1.1\r\nContent-Length: 4\r\n\r\nBODY";
         assert_eq!(expect, message_out);
     }
 }


### PR DESCRIPTION
Is required to let the client know not to continuously use a connection